### PR TITLE
"skip" string support

### DIFF
--- a/powermodes/config.py
+++ b/powermodes/config.py
@@ -303,7 +303,14 @@ def apply_mode(mode: str, config: ValidatedConfig, plugins: LoadedPlugins) -> \
 
 def plugin_is_in_all_powermodes(config: ValidatedConfig, plugin_name: str) -> \
     tuple[bool, Optional[Error]]:
-    """Checks if all powermodes have a configuration object for a given plugin.
+    """Checks if all powermodes have a configuration object for a given plugin. This is useful for
+    plugins that store state on the operating system (e.g.: CPU frequency limits), where having a
+    powermode unconfigured, and then applying it, will result in keeping whatever was configured
+    for the previously applied powermode.
+
+    As a guideline, a plugin can be configured with the string ``"skip"``, and it'll be recognized
+    as acknowledgment from the user that they are aware of the problem relating to stored operating
+    system state.
 
     :param config: A :data:`ValidatedConfig`.
     :param plugin_name: Name of the plugin to check for presence in all powermodes.

--- a/powermodes/plugins/intelepb.md
+++ b/powermodes/plugins/intelepb.md
@@ -26,6 +26,9 @@ processors.
 
 Source: https://elixir.bootlin.com/linux/v6.4.12/source/arch/x86/include/asm/msr-index.h#L837
 
+- The string `"skip"`, to signal that you're aware that you left a powermode not configured, and
+applying it will keep the settings from the last applied powermode.
+
 ### Example
 
 ``` toml

--- a/powermodes/plugins/nmiwatchdog.md
+++ b/powermodes/plugins/nmiwatchdog.md
@@ -5,7 +5,9 @@ periodically checks if the kernel has hung, resulting in a kernel panic. Disabli
 if the kernel hangs, you won't get a panic, and the system will keep looping forever. In return,
 you may get a slight improvement in power consumption.
 
-`nmi-watchdog` is simply configured with a boolean.
+`nmi-watchdog` is simply configured with a boolean. The string `"skip"` may also be used, to
+signal that you're aware that you left a powermode not configured, and applying it will keep the
+settings from the last applied powermode.
 
 ### Example
 

--- a/powermodes/plugins/nmiwatchdog.py
+++ b/powermodes/plugins/nmiwatchdog.py
@@ -23,14 +23,14 @@ Plugin to enable / disable the NMI (non-maskable interrupt) watchdog. See how to
 `here <../../../powermodes/plugins/nmiwatchdog.md>`_.
 """
 
-from typing import Any
+from typing import Any, Union
 
 from ..config import iterate_config, plugin_is_in_all_powermodes
 from ..error import Error, ErrorType, handle_error_append
 from ..pluginutils import write_text_file
 
 NAME = 'nmi-watchdog'
-VERSION = '1.0'
+VERSION = '1.1'
 
 def validate(config: dict[str, dict[str, Any]]) -> tuple[list[str], list[Error]]:
     """See :attr:`powermodes.plugin.Plugin.validate`."""
@@ -40,15 +40,18 @@ def validate(config: dict[str, dict[str, Any]]) -> tuple[list[str], list[Error]]
 
     successful: list[str] = []
     for powermode, config_obj in iterate_config(config, NAME):
-        if isinstance(config_obj, bool):
+        if isinstance(config_obj, bool) or config_obj == 'skip':
             successful.append(powermode)
         else:
-            errors.append(Error(ErrorType.WARNING, f'config in powermode {powermode} must be ' \
-                                                    'a boolean.'))
+            errors.append(Error(ErrorType.WARNING, f'config, in powermode "{powermode}" must ' \
+                                                    'be a boolean or the string "skip".'))
     return (successful, errors)
 
-def configure(config: bool) -> tuple[bool, list[Error]]:
+def configure(config: Union[bool, str]) -> tuple[bool, list[Error]]:
     """See :attr:`powermodes.plugin.Plugin.configure`."""
+
+    if isinstance(config, str): # "skip"
+        return (True, [])
 
     errors: list[Error] = []
     write_string = { False: '0\n', True: '1\n' }[config]


### PR DESCRIPTION
Allows users to ignore warnings from `config.plugin_is_in_all_powermodes`, by configuring the plugin with the string `"skip"`.